### PR TITLE
Fixes openactive/data-model-validator#222 - editor tab width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
       }
     },
     "@openactive/data-model-validator": {
-      "version": "github:openactive/data-model-validator#19f22e60f969842ad0181ee0eb7390d69aa13e3a",
+      "version": "github:openactive/data-model-validator#c231716398e6904bb8a9ce766b0186570970bff4",
       "from": "github:openactive/data-model-validator",
       "requires": {
         "@openactive/data-models": "github:openactive/data-models#f2765e62c8d2837b4261920e0e57515bb4485eb2",
@@ -114,7 +114,7 @@
       "version": "github:openactive/rpde-validator#37f022b29b71989e1b3827227fd5d00ac4a6cb82",
       "from": "github:openactive/rpde-validator",
       "requires": {
-        "@openactive/data-model-validator": "github:openactive/data-model-validator#19f22e60f969842ad0181ee0eb7390d69aa13e3a",
+        "@openactive/data-model-validator": "github:openactive/data-model-validator#c231716398e6904bb8a9ce766b0186570970bff4",
         "babel-core": "^6.26.3",
         "babel-plugin-transform-builtin-extend": "^1.1.2",
         "babel-preset-env": "^1.7.0",

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -358,6 +358,7 @@ export default class Home extends Component {
               height="100%"
               onChange={(newValue) => { this.onEditorChange(newValue); }}
               value={this.state.json}
+              tabSize={2}
               showPrintMargin={true}
               showGutter={true}
               highlightActiveLine={true}


### PR DESCRIPTION
Updated the editor tab width to be 2 spaces