### PR TITLE
Bug: Inconsistent validation responses for examples

### DIFF
--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -57,8 +57,9 @@ export default class Home extends Component {
         name: 'General',
       },
     };
-    const version = VersionHelper.getLatestVersion();
-    const validationMode = VersionHelper.getDefaultValidationMode(version);
+    this.params = queryString.parse(this.props.location.search);
+    const version = this.normalizeVersion();
+    const validationMode = this.normalizeValidationMode(version);
     this.state = {
       results: null,
       json: savedJson || '',
@@ -72,39 +73,28 @@ export default class Home extends Component {
       version,
       validationMode,
     };
-    this.params = queryString.parse(this.props.location.search);
-    this.processVersion(true);
+
     this.processUrl(true);
     this.props.history.listen((location) => {
       this.params = queryString.parse(location.search);
-      this.processVersion(false);
-      this.processUrl(false);
+      const historyVersion = this.normalizeVersion();
+      const historyValidationMode = this.normalizeValidationMode(historyVersion);
+      this.setState({ version: historyVersion, validationMode: historyValidationMode }, () => this.processUrl(false));
     });
   }
 
-  processVersion(isFirstRun) {
+  normalizeVersion() {
     if (typeof this.params.version !== 'undefined') {
-      const versions = VersionHelper.getVersions();
-      const version = versions[this.params.version];
-      if (typeof version !== 'undefined') {
-        if (isFirstRun) {
-          this.state.version = this.params.version;
-          this.processValidationMode(isFirstRun);
-        } else {
-          this.setState({ version: this.params.version }, this.processValidationMode.bind(this, isFirstRun));
-        }
-      }
+      return VersionHelper.getTranslatedVersion(this.params.version);
     }
+    return VersionHelper.getLatestVersion();
   }
 
-  processValidationMode(isFirstRun) {
-    const defaultValidationMode = VersionHelper.getDefaultValidationMode(this.state.version);
-    const validationMode = (typeof this.params.validationMode !== 'undefined' ? this.params.validationMode : defaultValidationMode);
-    if (isFirstRun) {
-      this.state.validationMode = validationMode;
-    } else {
-      this.setState({ validationMode });
+  normalizeValidationMode(version) {
+    if (typeof this.params.validationMode !== 'undefined') {
+      return this.params.validationMode;
     }
+    return VersionHelper.getDefaultValidationMode(version);
   }
 
   processUrl(isFirstRun) {

--- a/src/client/components/Samples.jsx
+++ b/src/client/components/Samples.jsx
@@ -20,7 +20,7 @@ export default class Samples extends Component {
         } else {
           exampleUrl = `https://www.openactive.io/data-models/versions/${version}/examples/${example.file}`;
         }
-        let linkUrl = `/?url=${encodeURIComponent(exampleUrl)}&version=${this.props.version}`;
+        let linkUrl = `/?url=${encodeURIComponent(exampleUrl)}&version=${version}`;
         if (example.validationMode) {
           linkUrl += `&validationMode=${encodeURIComponent(example.validationMode)}`;
         }


### PR DESCRIPTION
Selecting a sample would cause validation to be run with the validation mode that was previously set, not the validation mode associated with a sample.

Have fixed the state-setting logic to ensure it only runs validation after the state has been fully set.

Plus there were some issues with all the different ways of specifying and interpreting versions (for example, 2.0, 2.x and latest all get "translated" to 2.x but 2.x is not in the list of versions). This does not fix the mess of different version specifiers but it does remove an accidental misunderstanding of 2.x as `undefined` if not careful.