### PR TITLE
Validation mode styling

### DIFF
--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -385,7 +385,7 @@ export default class Home extends Component {
           </div>
           <div className="col-6 results-col">
             {helpText}
-            <Results results={this.state.results} filter={this.state.filter} sort={this.state.sort} group={this.state.group} severities={this.severities} tokenMap={this.state.tokenMap} onResultClick={path => this.onResultClick(path)} onResetFilters={() => this.resetFilter()}/>
+            <Results results={this.state.results} filter={this.state.filter} sort={this.state.sort} group={this.state.group} severities={this.severities} tokenMap={this.state.tokenMap} validationMode={this.state.validationMode} onResultClick={path => this.onResultClick(path)} onResetFilters={() => this.resetFilter()}/>
           </div>
         </div>
       </div>

--- a/src/client/components/Results.jsx
+++ b/src/client/components/Results.jsx
@@ -99,7 +99,7 @@ export default class Results extends Component {
         topMessage = (
           <div className="information-row text-center hero-sub validated">
             <p><FontAwesomeIcon icon="check-circle" size="4x" /></p>
-            <p>Great work, the validator found no issues with your data!</p>
+            <p>Great work, the validator found no issues with your data in "{this.props.validationMode}" mode!</p>
           </div>
         );
       } else if (filtered) {
@@ -141,13 +141,13 @@ export default class Results extends Component {
 
         topMessage = (
           <div className="result-summary">
-            <Pluralize singular="distinct message" count={items.length} /> (of which:{ofWhich}) [<Pluralize singular="message" count={this.props.results.length} /> in total returned]
+            <Pluralize singular="distinct message" count={items.length} /> (of which:{ofWhich}) [<Pluralize singular="message" count={this.props.results.length} /> in total returned from the validator in "{this.props.validationMode}" mode]
           </div>
         );
       } else {
         topMessage = (
           <div className="result-summary">
-            <Pluralize singular="message" count={this.props.results.length} /> returned from the validator
+      <Pluralize singular="message" count={this.props.results.length} /> returned from the validator in "{this.props.validationMode}" mode
           </div>
         );
       }

--- a/src/client/components/Results.jsx
+++ b/src/client/components/Results.jsx
@@ -141,7 +141,7 @@ export default class Results extends Component {
 
         topMessage = (
           <div className="result-summary">
-            <Pluralize singular="distinct message" count={items.length} /> (of which:{ofWhich}) [<Pluralize singular="message" count={this.props.results.length} /> in total returned from the validator in "{this.props.validationMode}" mode]
+            <Pluralize singular="distinct message" count={items.length} /> (of which:{ofWhich}) [<Pluralize singular="message" count={this.props.results.length} /> in total] returned from the validator in "{this.props.validationMode}" mode
           </div>
         );
       } else {

--- a/src/client/components/ValidationMode.jsx
+++ b/src/client/components/ValidationMode.jsx
@@ -17,16 +17,11 @@ export default class ValidationMode extends Component {
     const meta = VersionHelper.getVersionMetaData(this.props.version);
     const { validationModeGroups } = meta;
 
-    let selectedValidationMode;
-
     const modeGroups = [];
     validationModeGroups.forEach((group, groupIndex) => {
       const modeList = [];
       for (const validationModeObj of group.validationModeList) {
         const isChecked = (this.props.validationMode === validationModeObj.validationMode);
-        if (isChecked) {
-          selectedValidationMode = validationModeObj.name;
-        }
         modeList.push(
           (
             <div key={`validation-mode-${validationModeObj.validationMode}-radio`} className={`form-check dropdown-item ${isChecked ? 'checked' : ''}`} onClick={e => this.handleValidationModeClick(e, validationModeObj.validationMode)}>
@@ -53,7 +48,7 @@ export default class ValidationMode extends Component {
       <div className="validation-mode-switcher float-right">
         <div className="dropdown">
           <button className="btn btn-primary dropdown-toggle" type="button" id="validationModeMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              {selectedValidationMode}
+              Mode
           </button>
           <form className="dropdown-menu p-3" aria-labelledby="validationModeMenuButton">
             {modeGroups}


### PR DESCRIPTION
Fix a further CSS issue with the menu (the changing displayed value of the validation mode drop down makes the layout unpredictable and it doesn't cope well with long values).

To minimise the chances of further, this PR makes the text on the button read a static "Mode" and adds the mode to the text below, e.g. 12 messages returned from the validator in "C1 Request" mode.